### PR TITLE
# TASK-15

### DIFF
--- a/src/components/ItemPreview.vue
+++ b/src/components/ItemPreview.vue
@@ -1,5 +1,6 @@
 <script setup>
 import ItemDataField from '@/components/ItemDataField.vue';
+import AddItemDialog from '@/components/AddItemDialog.vue';
 import { ref } from 'vue';
 
 defineProps({
@@ -10,52 +11,64 @@ defineProps({
     datafield_width: {
         type: String,
         default: '80%'
-    }
+    },
 });
 
-const dialog = ref(true);
+const dialog = ref(false);
+
+const openDialog = () => {
+    dialog.value = true;
+}
+
+const onClickEditButton = () => {
+    openDialog();
+}
+
 </script>
 
 <template>
-    <v-dialog v-model="dialog" max-width="800">
-        <v-card class="py-10">
-            <v-row justify="center">
-                <v-col cols="auto">
-                    <h1>
-                        商品名
-                    </h1>
-                </v-col>
-            </v-row>
+    <v-card class="py-10">
+        <v-row justify="center">
+            <v-col cols="auto">
+                <h1>
+                    商品名
+                </h1>
+            </v-col>
+        </v-row>
 
-            <v-row justify="center" class="my-4">
-                <v-col cols="auto">
-                    <v-btn
-                        color="primary"
-                        class="mybtn font-weight-bold"
-                        @click="dialog = false"
-                    >
-                        編集
-                    </v-btn>
-                </v-col>
-            </v-row>
+        <v-row justify="center" class="my-4">
+            <v-col cols="auto">
+                <v-btn
+                    color="primary"
+                    class="mybtn font-weight-bold"
+                    @click="onClickEditButton"
+                >
+                    編集
+                </v-btn>
+            </v-col>
+        </v-row>
+            
+        <!-- ItemDataFieldを動的に生成 -->
+        <v-row justify="center">
+            <v-col v-for="(info, index) in informations" :key="index" cols="12" class=" text-center">
+                <v-divider></v-divider>
 
-                
-               
-            <!-- ItemDataFieldを動的に生成 -->
-            <v-row justify="center">
-                <v-col v-for="(info, index) in informations" :key="index" cols="12" class=" text-center">
-                    <v-divider></v-divider>
+                <ItemDataField
+                    :label="info.label"
+                    :value="info.value"
+                    :width="datafield_width"
+                    class="my-4"
+                ></ItemDataField>
+            </v-col>
+        </v-row>
+    </v-card>
+    
 
-                    <ItemDataField
-                        :label="info.label"
-                        :value="info.value"
-                        :width="datafield_width"
-                        class="my-4"
-                    ></ItemDataField>
-                </v-col>
-            </v-row>
-        </v-card>
-        
+    <v-dialog
+        v-model="dialog"
+        max-width="400"
+    >
+        <AddItemDialog />
     </v-dialog>
 </template>
 


### PR DESCRIPTION
## やったこと

* アイテムプレビューからアイテム登録ウィンドウを開けるように
  * まだ登録ダイアログをそのまま表示しているだけ（ボタンが「登録する」のまま）

## やらないこと

* 「変更する」ボタンの機能は未実装
  * 「登録する」ボタンに関数を渡すことで切り替えられるように実装する予定

## できるようになること（ユーザ目線）

* アイテムプレビューからアイテム登録ダイアログが開ける

## できなくなること（ユーザ目線）

* なし

## 動作確認

* 「編集」ボタンを押して表示されたダイアログ
  * 少し変だが、同時作業していたブランチとマージしたら直るはず
 
<img width="589" alt="image" src="https://github.com/user-attachments/assets/39591ba8-2de4-4bbf-b2bc-c6d9297fdcac">

## その他

* なし