### PR TITLE
# TASK-17

### DIFF
--- a/src/components/AddItemDialog.vue
+++ b/src/components/AddItemDialog.vue
@@ -11,23 +11,17 @@ const quantity = ref(0);
 
 const emit = defineEmits(['update:title', 'update:quantity', 'update:date'])
 
-/**
- * フォームの入力内容をFirestoreに登録する
- */
-const submitForm = async () => {
-    const addItem = {
-        title: title.value,
-        quantity: quantity.value,
-        deadline: date.value,
-        createdAt: new Date()
-    }
+defineProps({
+    button_function: {
+        type: Function,
+        default: () => { console.log('ボタンが押されました') }
+    },
+    button_text: {
+        type: String,
+        default: 'button'
+    },
+});
 
-    try {
-        await create(['items'], addItem);
-    } catch (error) {
-        console.error(error);
-    }
-}
 </script>
 
 <template>
@@ -61,9 +55,9 @@ const submitForm = async () => {
             <v-btn
                 color="primary"
                 class="my-btn font-weight-bold"
-                @click="submitForm"
+                @click="button_function(title, quantity, date)"
             >
-                登録する
+                {{ button_text }}
             </v-btn>
         </div>
     </v-card>

--- a/src/components/AddItemDialog.vue
+++ b/src/components/AddItemDialog.vue
@@ -9,7 +9,7 @@ const date = ref('');
 const title = ref('');
 const quantity = ref(0);
 
-const emit = defineEmits(['update:title', 'update:quantity', 'update:date'])
+const emit = defineEmits(['update:title', 'update:quantity', 'update:date', 'close'])
 
 defineProps({
     button_function: {
@@ -22,6 +22,11 @@ defineProps({
     },
 });
 
+// ダイアログを閉じるための関数
+const closeDialog = () => {
+    emit('close');
+};
+
 </script>
 
 <template>
@@ -31,7 +36,7 @@ defineProps({
             <v-btn
                 icon
                 variant="text"
-                @click="closeDialog"
+                @click=closeDialog
             >
                 <v-icon>mdi-close</v-icon>
             </v-btn>

--- a/src/components/ItemPreview.vue
+++ b/src/components/ItemPreview.vue
@@ -91,6 +91,7 @@ const onClickEditButton = () => {
         <AddItemDialog 
             :button_function="submitEditData"
             button_text="変更を保存する"
+            @close="dialog = false"
         />
     </v-dialog>
 </template>

--- a/src/components/ItemPreview.vue
+++ b/src/components/ItemPreview.vue
@@ -24,6 +24,26 @@ const onClickEditButton = () => {
     openDialog();
 }
 
+/**
+ * フォームで入力された変更内容を反映させる
+ * （詳細な実装は後回し中）
+ */
+ const submitEditData = async (title, quantity, date) => {
+    // const addItem = {
+    //     title: title,
+    //     quantity: quantity,
+    //     deadline: date,
+    //     createdAt: new Date()
+    // }
+
+    // try {
+    //     await create(['items'], addItem);
+    // } catch (error) {
+    //     console.error(error);
+    // }
+    console.log('変更を保存するボタンが押されました')
+}
+
 </script>
 
 <template>
@@ -68,7 +88,10 @@ const onClickEditButton = () => {
         v-model="dialog"
         max-width="400"
     >
-        <AddItemDialog />
+        <AddItemDialog 
+            :button_function="submitEditData"
+            button_text="変更を保存する"
+        />
     </v-dialog>
 </template>
 

--- a/src/components/ItemPreview.vue
+++ b/src/components/ItemPreview.vue
@@ -4,6 +4,10 @@ import AddItemDialog from '@/components/AddItemDialog.vue';
 import { ref } from 'vue';
 
 defineProps({
+    title: {
+        type: String,
+        default: '商品名'
+    },
     informations: {
         type: Array,
         required: true
@@ -51,7 +55,7 @@ const onClickEditButton = () => {
         <v-row justify="center">
             <v-col cols="auto">
                 <h1>
-                    商品名
+                    {{ title }} 
                 </h1>
             </v-col>
         </v-row>

--- a/src/components/ItemPreview.vue
+++ b/src/components/ItemPreview.vue
@@ -3,6 +3,8 @@ import ItemDataField from '@/components/ItemDataField.vue';
 import AddItemDialog from '@/components/AddItemDialog.vue';
 import { ref } from 'vue';
 
+const emit = defineEmits(['close'])
+
 defineProps({
     title: {
         type: String,
@@ -28,6 +30,11 @@ const onClickEditButton = () => {
     openDialog();
 }
 
+// ダイアログを閉じるための関数
+const closeDialog = () => {
+    emit('close');
+};
+
 /**
  * フォームで入力された変更内容を反映させる
  * （詳細な実装は後回し中）
@@ -51,7 +58,17 @@ const onClickEditButton = () => {
 </script>
 
 <template>
-    <v-card class="py-10">
+    <v-card class="custom-padding">
+        <v-card-title class="d-flex justify-end pa-0 mb-4 close-btn-wrapper">
+            <v-btn
+                icon
+                variant="text"
+                @click=closeDialog
+            >
+                <v-icon>mdi-close</v-icon>
+            </v-btn>
+        </v-card-title>
+
         <v-row justify="center">
             <v-col cols="auto">
                 <h1>
@@ -104,5 +121,15 @@ const onClickEditButton = () => {
 .my-btn {
     /* width: 40%; */
     margin: 20px 0;
+}
+
+.form-content {
+    position: relative;
+    padding-top: 48px;
+}
+
+.custom-padding {
+    padding-top: 8px; /* 上の余白 */
+    padding-bottom: 32px; /* 下の余白 */
 }
 </style>

--- a/src/components/TodoItem.vue
+++ b/src/components/TodoItem.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, ref } from 'vue';
+import ItemPreview from '@/components/ItemPreview.vue';
 
 const props = defineProps({
     id: {
@@ -60,36 +61,14 @@ const formattedDateTime = computed(() => {
             v-model="dialog"
             max-width="500px"
         >
-            <v-card>
-                <v-card-title class="text-h5 mb-2">
-                    {{ title }}
-                </v-card-title>
-
-                <v-card-text>
-                    <div class="detail-grid">
-                        <div class="detail-item">
-                            <div class="detail-label">登録日時</div>
-                            <div>{{ formattedDateTime }}</div>
-                        </div>
-                        
-                        <div class="detail-item">
-                            <div class="detail-label">数量</div>
-                            <div>{{ quantity }}</div>
-                        </div>
-                    </div>
-                </v-card-text>
-
-                <v-card-actions>
-                    <v-spacer></v-spacer>
-                    <v-btn
-                        color="primary"
-                        variant="text"
-                        @click="dialog = false"
-                    >
-                        閉じる
-                    </v-btn>
-                </v-card-actions>
-            </v-card>
+            <ItemPreview 
+                :informations="[
+                    { label: '個数', value: quantity},
+                    { label: '期限', value: formattedDateTime },
+                    { label: 'メモ帳', value: 'ドラッグストア' },
+                ]"
+                @close="dialog = false"
+            />
         </v-dialog>
     </div>
 </template>

--- a/src/components/TodoItem.vue
+++ b/src/components/TodoItem.vue
@@ -62,12 +62,13 @@ const formattedDateTime = computed(() => {
             max-width="500px"
         >
             <ItemPreview 
+                :title="title"
                 :informations="[
                     { label: '個数', value: quantity},
                     { label: '期限', value: formattedDateTime },
                     { label: 'メモ帳', value: 'ドラッグストア' },
                 ]"
-                @close="dialog = false"
+                
             />
         </v-dialog>
     </div>

--- a/src/components/TodoItem.vue
+++ b/src/components/TodoItem.vue
@@ -68,7 +68,7 @@ const formattedDateTime = computed(() => {
                     { label: '期限', value: formattedDateTime },
                     { label: 'メモ帳', value: 'ドラッグストア' },
                 ]"
-                
+                @close="dialog = false"
             />
         </v-dialog>
     </div>

--- a/src/views/containers/HomeContainer.vue
+++ b/src/views/containers/HomeContainer.vue
@@ -13,7 +13,7 @@ const openDialog = () => {
 /**
  * フォームの入力内容をFirestoreに登録する
  */
- const submitForm = async (title, quantity, date) => {
+ const submitNewData = async (title, quantity, date) => {
     const addItem = {
         title: title,
         quantity: quantity,
@@ -71,7 +71,7 @@ const onClickPlusButton = () => {
         max-width="400"
     >
         <AddItemDialog 
-            :button_function="submitForm"
+            :button_function="submitNewData"
             button_text="登録する"
         />
     </v-dialog>

--- a/src/views/containers/HomeContainer.vue
+++ b/src/views/containers/HomeContainer.vue
@@ -10,6 +10,24 @@ const openDialog = () => {
     dialog.value = true;
 }
 
+/**
+ * フォームの入力内容をFirestoreに登録する
+ */
+ const submitForm = async (title, quantity, date) => {
+    const addItem = {
+        title: title,
+        quantity: quantity,
+        deadline: date,
+        createdAt: new Date()
+    }
+
+    try {
+        await create(['items'], addItem);
+    } catch (error) {
+        console.error(error);
+    }
+}
+
 defineProps({
     items: {
         type: Array,
@@ -53,6 +71,8 @@ const onClickPlusButton = () => {
         max-width="400"
     >
         <AddItemDialog 
+            :button_function="submitForm"
+            button_text="登録する"
         />
     </v-dialog>
 </template>

--- a/src/views/containers/HomeContainer.vue
+++ b/src/views/containers/HomeContainer.vue
@@ -73,6 +73,7 @@ const onClickPlusButton = () => {
         <AddItemDialog 
             :button_function="submitNewData"
             button_text="登録する"
+            @close="dialog = false"
         />
     </v-dialog>
 </template>

--- a/src/views/containers/WrapperContainer.vue
+++ b/src/views/containers/WrapperContainer.vue
@@ -83,6 +83,7 @@ const signout = () => {
                 <AddItemDialog 
                     :button_function="submitNewData"
                     button_text="登録する"
+                    @close="dialog = false"
                 />
             </v-dialog>
         </div>

--- a/src/views/containers/WrapperContainer.vue
+++ b/src/views/containers/WrapperContainer.vue
@@ -5,6 +5,7 @@ import Navigationvar from '@/components/Navigationvar.vue';
 import { navigate } from '@/function';
 import { signOut } from 'firebase/auth';
 import { firebaseAuth } from '@/config/firebase';
+import { create } from '@/firestoreOperation';
 import FloatingActionButtons from '@/components/FloatingActionButtons.vue';
 import AddItemDialog from '@/components/AddItemDialog.vue';
 
@@ -34,6 +35,23 @@ const signout = () => {
         console.error('Sign out error:', error);
     });
 };
+
+/**
+ * フォームの入力内容をFirestoreに登録する
+ */
+ const submitNewData = async (title, quantity, date) => {
+    const addItem = {
+        title: title,
+        quantity: quantity,
+        deadline: date,
+        createdAt: new Date()
+    }
+    try {
+        await create(['items'], addItem);
+    } catch (error) {
+        console.error(error);
+    }
+}
 </script>
 
 <template>
@@ -63,6 +81,8 @@ const signout = () => {
                 max-width="400"
             >
                 <AddItemDialog 
+                    :button_function="submitNewData"
+                    button_text="登録する"
                 />
             </v-dialog>
         </div>


### PR DESCRIPTION
## やったこと

* アイテムの登録ダイアログを用途に応じて処理を切り替えられるようにした
* 各種ダイアログを×ボタンで閉じれるようにした

## やらないこと

* アイテムの編集に関する処理は未実装

## できるようになること（ユーザ目線）

* 各種ダイアログを×ボタンで閉じることができるようになる

## できなくなること（ユーザ目線）

* なし

## 動作確認

* アイテムの登録ダイアログ
<img width="442" alt="image" src="https://github.com/user-attachments/assets/670bdadc-2333-4152-9e71-51c8d147d92d">


* アイテムの修正ダイアログ
<img width="449" alt="image" src="https://github.com/user-attachments/assets/e2e48613-988e-419b-a28c-23c258350c48">


## その他

* なし